### PR TITLE
Update config option name to remove issue with iOS

### DIFF
--- a/src/webrtc/media-plugin.js
+++ b/src/webrtc/media-plugin.js
@@ -33,7 +33,7 @@ MediaPlugin.prototype.createPeerConnection = function(options) {
   options = Helpers.extend(options || {}, this._session._connection._options.pc);
 
   var config = {
-    iceServers: [{url: 'stun:stun.l.google.com:19302'}]
+    iceServers: [{urls: 'stun:stun.l.google.com:19302'}]
   };
   var constraints = {
     'optional': [{'DtlsSrtpKeyAgreement': true}]


### PR DESCRIPTION
Thanks for the library - it's great.  This pull request seems to fix an issue starting webRTC video stream to iOS due to depricated config option name. Cheers