### PR TITLE
removed useless build sections & add gulp dist directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ typings/
 
 # DynamoDB Local files
 .dynamodb/
+
+# gulp dist directory
+dist/

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Project has a simple build. By default `npm run-script build` it builds the sing
    $(npm bin)/gulp
    ```
 
+ - `bluebird` and `webrtc-adapter` are externalized to `vendor.js`
+
+   ```
+   $(npm bin)/gulp external
+   ```
+
 ## API
 
 The library is available for Node and Browser environment. In Browser it is declared through `window.Janus`. The exported classes are:

--- a/README.md
+++ b/README.md
@@ -25,23 +25,12 @@ janus.createConnection('id').then(function(connection) {
 ```
 
 ## Build
-Project has a customized build. By default `npm run-script build` it builds the single file `janus.js` that contains Janus library and all its dependencies. In order to make the result less in size you have two command line arguments: `--global` and `--external`. The first is to map dependencies to global variables. Usually you want to do this when there is no loader mechanism. The latter is to externalize dependencies to a separate file `vendor.js`. In that case `janus.js` expects to have its dependencies as modules and relies on `require` mechanism.
-Here is the couple of examples.
+Project has a simple build. By default `npm run-script build` it builds the single file `janus.js` that contains Janus library and all its dependencies.
+
  - Default build. It is used in integration tests.
 
    ```
    $(npm bin)/gulp
-   ```
-
- - `bluebird` and `webrtc-adapter` are externalized to `vendor.js`
-
-   ```
-   $(npm bin)/gulp --external=bluebird --external=webrtc-adapter
-   ```
- - `bluebird` and `webrtc-adapter` are expected to be in global namespace under names `Promise` and `adapter` correspondingly.
-
-   ```
-   $(npm bin)/gulp --global.bluebird=Promise --global.webrtc-adapter=adapter
    ```
 
 ## API

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,6 @@ var uglify = require('gulp-uglify');
 var sourcemaps = require('gulp-sourcemaps');
 var log = require('fancy-log');
 var exorcist = require('exorcist');
-var nodeResolve = require('resolve');
 
 var browserifyTask = function() {
   var b = browserify({
@@ -30,38 +29,7 @@ var browserifyTask = function() {
     .pipe(gulp.dest('./dist'));
 };
 
-var vendorTask = function(external) {
-  var b = browserify();
-  if (external) {
-    if (!_.isArray(external)) {
-      external = [external];
-    }
-    external.forEach(function(id) {
-      b.require(nodeResolve.sync(id), {expose: id});
-    });
-
-    var stream = b
-      .bundle()
-      .on('error', function(err) {
-        console.log(err.message);
-        this.emit('end');
-      })
-      .pipe(source('vendor.js'));
-
-    stream
-      .pipe(gulp.dest('./dist'))
-      .pipe(rename('vendor.min.js'))
-      .pipe(buffer())
-      .pipe(uglify())
-      .pipe(gulp.dest('./dist'));
-
-    return stream;
-  }
-};
-
-
 function build(cb) {
-  vendorTask();
   browserifyTask();
   cb();
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -56,7 +56,6 @@ var vendorTask = function(external) {
 };
 
 function build(cb) {
-  vendorTask();
   browserifyTask();
   cb();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -527,9 +527,9 @@
       "dev": true
     },
     "bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
     },
     "bn.js": {
       "version": "4.11.8",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test-codecov": "$(npm bin)/istanbul cover $(npm bin)/_mocha -- --exit -R spec && cat ./coverage/coverage.json | $(npm bin)/codecov"
   },
   "dependencies": {
-    "bluebird": "^3.0.0",
+    "bluebird": "3.5.5",
     "eventemitter2": "^2.1.3",
     "webrtc-adapter": "~1.1.0",
     "webrtcsupport": "^2.2.0",


### PR DESCRIPTION
It seems that the old way of using --global or --external arguments to the build process doesn't function anymore. This is confusing for new people so the proposed deletion.
Add gulp dist directory to .gitignore